### PR TITLE
push the next words onto the result array

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,7 +168,7 @@ module.exports = function (order) {
                 ncur = null;
                 if (next) {
                     ncur = next.key;
-                    res.unshift(next.word);
+                    res.push(next.word);
                     if (limit && res.length >= limit) break;
                 }
             }


### PR DESCRIPTION
Hello! Thank you for all the modules :surfer: 

I noticed that `fill` was returning stuff that seemed slightly out of order, by doing a push on the next words the results end up looking like `[..., previousWords, currentWord, nextWords, ...]`, rather than `[lastWord, firstWord, ...,  currentWord]`. 