### PR TITLE
Remove has() usage to avoid Object.key() 100k limit

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = function (order) {
                 var link = words.slice(i, i + order).join(' ');
                 links.push(link);
             }
-            
+
             if (links.length <= 1) {
                 if (cb) cb(null);
                 return;
@@ -38,7 +38,7 @@ module.exports = function (order) {
                 var next = links[i];
                 var cnext = clean(next);
                 
-                var node = Hash.has(db, cword)
+                var node = db[cword] !== undefined
                     ? db[cword]
                     : {
                         count : 0,
@@ -50,32 +50,25 @@ module.exports = function (order) {
                 db[cword] = node;
                 
                 node.count ++;
-                node.words[word] = (
-                    Hash.has(node.words, word) ? node.words[word] : 0
-                ) + 1;
-                node.next[cnext] = (
-                    Hash.has(node.next, cnext) ? node.next[cnext] : 0
-                ) + 1
+                node.words[word] = node.words[word] === undefined ? 1 : node.words[word] + 1;
+                node.next[cnext] = node.next[cnext] === undefined ? 1 : node.next[cnext] + 1;
                 if (i > 1) {
                     var prev = clean(links[i-2]);
-                    node.prev[prev] = (
-                        Hash.has(node.prev, prev) ? node.prev[prev] : 0
-                    ) + 1;
+                    node.prev[prev] = node.prev[prev] === undefined ? 1 : node.prev[prev] + 1;
                 }
                 else {
                     node.prev[''] = (node.prev[''] || 0) + 1;
                 }
             }
-            
-            if (!Hash.has(db, cnext)) db[cnext] = {
+            if (db[cnext] === undefined) db[cnext] = {
                 count : 1,
                 words : {},
                 next : { '' : 0 },
                 prev : {},
             };
             var n = db[cnext];
-            n.words[next] = (Hash.has(n.words, next) ? n.words[next] : 0) + 1;
-            n.prev[cword] = (Hash.has(n.prev, cword) ? n.prev[cword] : 0) + 1;
+            n.words[next] = n.words[next] === undefined ? 1 : n.words[next] + 1;
+            n.prev[cword] = n.prev[cword] === undefined ? 1 : n.prev[cword] + 1;
             n.next[''] = (n.next[''] || 0) + 1;
             
             if (cb) cb(null);


### PR DESCRIPTION
Hi again, 

This pull request should definitely take precedence over my previous one. 

While attempting to make a markov chain seeded with a rather large file (120000 lines of text) I ran into a hard limit at around line 50,000. It turns out this is due to the way that V8 handles arrays - arrays of 100000 are treated differently than any smaller array and we see a huge drop in speed (about a line per min). 

This stack overflow issue talks a bit about this problem:
http://stackoverflow.com/questions/16961838/working-with-arrays-in-v8-performance-issue
Which is located here in the V8 code:
https://github.com/v8/v8/blob/abfa9f17410a2a84c2ac3364e0288f4a8311b9b1/src/objects.h#L2411

Since this library relies on the Object.keys() method (specifically in Hash.has()), which returns an array we are at risk of hitting this hard limit. 

In this PR I removed the usage of Hash.has() in favor of a boolean assignment call, which seems to speed up the entire seeding process quite a bit. 

On my larger files I'm seeing the times change from 1 hour per seed down to 1 minute.