### PR TITLE
Fix issue with word order causing weird sentences

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ module.exports = function (order) {
     self.fill = function (cur, limit) {
         var res = [ deck.pick(db[cur].words) ];
         if (!res[0]) return [];
-        if (limit && res.length >= limit) return res;;
+        if (limit && res.length >= limit) return res;
         
         var pcur = cur;
         var ncur = cur;
@@ -168,7 +168,7 @@ module.exports = function (order) {
                 ncur = null;
                 if (next) {
                     ncur = next.key;
-                    res.unshift(next.word);
+                    res.push(next.word);
                     if (limit && res.length >= limit) break;
                 }
             }


### PR DESCRIPTION
I noticed some sentences seemed weird, and sometimes reversing the result would make more sense.
After looking at the code, I believe the reason is that the words in the `next` chain are being added to the beginning of the result, alternating with the words in the `prev` chain.
Pushing them instead of unshifting should place these words to the 'right' of the initial word.