### PR TITLE
feat: allow user to set db directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,14 @@ module.exports = function (order) {
     var db = {};
     var self = {};
     
+    self.setDb = function (userDb) {
+      db = userDb;
+    }
+
+    self.getDb = function () {
+      return db;
+    }
+
     self.seed = function (seed, cb) {
         if (seed instanceof EventEmitter) {
             Lazy(seed).lines.forEach(self.seed);


### PR DESCRIPTION
Since seeding can be the most intensive process of generating a new chain, I wanted to be able to provide the DB without seeding the corpus every time. These methods allow for that.