### PR TITLE
Fix limits on the fill function

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ module.exports = function (order) {
             }
         }
         
-        return res;
+        return self.fill(cur,limit-res.length).concat(res);
     };
     
     self.respond = function (text, limit) {


### PR DESCRIPTION
Fill was only checking for the limit on line 150. 

This resulted in all calls just being dumped as a response later regardless of the limit not being reached yet. I figure a quick recursive call to cause it to continue to fill until the limit is reached would get this working. It tests ok on my end but I only use the respond function.